### PR TITLE
Update build configuration for Android 26 in Ubuntu Trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,17 @@
 language: android
+
+dist: trusty
+sudo: required 
+
 android:
   components:
     - tools
     - platform-tools
-    - build-tools
+    - android-26
+    - build-tools-26.0.1
 
+    
+    
 before_install:
+- echo "y" | sdkmanager "extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.2"
 - chmod +x gradlew


### PR DESCRIPTION
Hope this helps! :-)

See https://github.com/travis-ci/travis-ci/issues/5370 for further updates about the Android environment in Trusty.